### PR TITLE
 Detach instance from ASG if ASG_NAME is available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,13 @@ ARG KUBE_VERSION=1.12.0
 ENV HOME=/srv
 WORKDIR /srv
 
-RUN apk add --no-cache curl ca-certificates
+RUN apk -v --update add --no-cache \
+      curl ca-certificates \
+      python \
+      py-pip \
+      && \
+    pip install awscli
+
 RUN curl -f -s -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     kubectl version --client

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Slack Setup:
 Show where things are happening by setting the `CLUSTER` environment variable to whatever you call your cluster.
 Very handy if you have several clusters that report to the same Slack channel.
 
+## Using ASG for instances
+Add "ASG_NAME" environment variable in case you want the handler to detach the instance when termination notice is available. DesiredCapacity will not be reduced while detaching the instance, which will cause the replacement spot node to be launched.
+
 Example Pod Spec:
 
 ```


### PR DESCRIPTION
After an instance is terminated, it takes time for ASG to identify this and launch a new replacement instance. 
To cater to this time window, this PR makes sure that before triggering `kubectl drain` on the instance, the instance is detached from that ASG. ASG will itself launch the replacement instance (this availability chances are now more after the release of https://aws.amazon.com/blogs/aws/new-ec2-auto-scaling-groups-with-multiple-instance-types-purchase-options/)

Changes:
1. Take an environment variable "ASG_NAME" to which instance is attached. 
2. If the environment variable is set, detach the instance from that ASG