### PR TITLE
Update helm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Once a termination notice is received, it will try to gracefully stop all the po
 
 ### Helm
 
-A helm chart has been created for this tool, and at time of writing was in the `incubator` repository.
+A helm chart has been created for this tool, and at time of writing was in the `stable` repository.
 
     $ helm install stable/kube-spot-termination-notice-handler
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Once a termination notice is received, it will try to gracefully stop all the po
 
 A helm chart has been created for this tool, and at time of writing was in the `stable` repository.
 
-    $ helm install stable/kube-spot-termination-notice-handler
+    $ helm install stable/k8s-spot-termination-handler
 
 ## Available docker images/tags
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Once a termination notice is received, it will try to gracefully stop all the po
 
 A helm chart has been created for this tool, and at time of writing was in the `incubator` repository.
 
-    $ helm install incubator/kube-spot-termination-notice-handler
+    $ helm install stable/kube-spot-termination-notice-handler
 
 ## Available docker images/tags
 


### PR DESCRIPTION
The helm chart for `kube-spot-termination-notice-handle` is now in `stable`
and no longer in `incubator`.