### PR TITLE
Run as nobody instead of root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ COPY entrypoint.sh .
 # Set permissions on the file.
 RUN chmod +x entrypoint.sh
 
+USER nobody
 
 CMD ["/srv/entrypoint.sh"]


### PR DESCRIPTION
This change makes the container run as `nobody` instead of `root` which is safer :)