### PR TITLE
fix issue with launchtemplates

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ INSTANCE_TYPE_URL=${INSTANCE_TYPE_URL:-http://169.254.169.254/latest/meta-data/i
 INSTANCE_TYPE=$(curl -s "${INSTANCE_TYPE_URL}")
 
 if [ "${DETACH_ASG}" != "false" ]; then
-  ASG_NAME=$(aws --output text --region "${REGION}" autoscaling describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}" | awk '$1 == "AUTOSCALINGINSTANCES" {print $2}')
+  ASG_NAME=$(aws --output text --query 'AutoScalingInstances[0].AutoScalingGroupName' --region "${REGION}" autoscaling describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}")
 fi
 
 if [ -z "$CLUSTER" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ INSTANCE_TYPE_URL=${INSTANCE_TYPE_URL:-http://169.254.169.254/latest/meta-data/i
 INSTANCE_TYPE=$(curl -s "${INSTANCE_TYPE_URL}")
 
 if [ "${DETACH_ASG}" != "false" ]; then
-  ASG_NAME=$(aws --output text --region "${REGION}" autoscaling describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}" |awk '{print $2}')
+  ASG_NAME=$(aws --output text --region "${REGION}" autoscaling describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}" | awk '$1 == "AUTOSCALINGINSTANCES" {print $2}')
 fi
 
 if [ -z "$CLUSTER" ]; then


### PR DESCRIPTION
if DETACH_ASG is active and LaunchTemplates are used, the ASG name isn't
detected properly as the aws command output differs:

without LaunchTemplate
```
$ aws --output text --region us-east-1 autoscaling describe-auto-scaling-instances --instance-ids i-abcdefg
AUTOSCALINGINSTANCES    instancegroupname.clustername.domain.name       us-east-1c HEALTHY i-abcdefg     InService       False
```

with LaunchTemplate
```
$ aws --output text --region us-east-1 autoscaling describe-auto-scaling-instances --instance-ids i-abcdefg
AUTOSCALINGINSTANCES    instancegroupname.clustername.domain.name       us-east-1c HEALTHY i-abcdefg     InService       False
LAUNCHTEMPLATE  lt-zyxw1234    instancegroupname.clustername.domain.name-19700101000000000000    1
```