### PR TITLE
fix(aws): use JSON output instead of raw text

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG KUBE_VERSION=1.13.7
 ENV HOME=/srv
 WORKDIR /srv
 
-RUN apk add --no-cache curl ca-certificates && \
+RUN apk add --no-cache curl ca-certificates jq && \
     pip --no-cache-dir --disable-pip-version-check --quiet install awscli
 RUN curl -f -s -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ INSTANCE_TYPE_URL=${INSTANCE_TYPE_URL:-http://169.254.169.254/latest/meta-data/i
 INSTANCE_TYPE=$(curl -s "${INSTANCE_TYPE_URL}")
 
 if [ "${DETACH_ASG}" != "false" ]; then
-  ASG_NAME=$(aws --output text --query 'AutoScalingInstances[0].AutoScalingGroupName' --region "${REGION}" autoscaling describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}")
+  ASG_NAME=$(aws --output json --region "${REGION}" autoscaling describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}" | jq -r '.AutoScalingInstances[0].AutoScalingGroupName' )
 fi
 
 if [ -z "$CLUSTER" ]; then


### PR DESCRIPTION
AWS raw text output has been updated since this script has been written.
Now the text output  has 2 lines instead of  1 : thus the "awk" command used to parse
its output returns a string with a linebreak and 2 lines of text.
Using JSON instead of raw text makes the parsing much more easier,
provided we use the jq program.